### PR TITLE
Route loading breaks CMS when no DB set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added hover state to editable items in the content editor. [#6](https://github.com/Aldrumo/core/issues/6)
 * Added ability to update page title [#4](https://github.com/Aldrumo/core/issues/4)
 * Added ability to update page slug [#5](https://github.com/Aldrumo/core/issues/5)
+* Fixed issue where no DB connection would break route loading. [#8](https://github.com/Aldrumo/core/issues/8)
 
 ## [0.1.7 - 2021-02-22](https://github.com/Aldrumo/core/releases/tag/0.1.7)
 

--- a/src/Routes/Loader.php
+++ b/src/Routes/Loader.php
@@ -4,6 +4,7 @@ namespace Aldrumo\Core\Routes;
 
 use Aldrumo\Core\Models\Page;
 use Aldrumo\RouteLoader\Contracts\RouteLoader;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Collection;
 
 class Loader implements RouteLoader
@@ -12,7 +13,7 @@ class Loader implements RouteLoader
     {
         try {
             return Page::where('is_active', true)->get();
-        } catch (\Exception $e) {
+        } catch (QueryException $e) {
             return collect([]);
         }
     }

--- a/src/Routes/Loader.php
+++ b/src/Routes/Loader.php
@@ -10,6 +10,10 @@ class Loader implements RouteLoader
 {
     public function getRoutes(): Collection
     {
-        return Page::where('is_active', true)->get();
+        try {
+            return Page::where('is_active', true)->get();
+        } catch (\Exception $e) {
+            return collect([]);
+        }
     }
 }


### PR DESCRIPTION
Fixes #8 

When Aldrumo has been previously installed but then no DB connection exists.
e.g.
Developed locally, and initially deploy live can fail due to it trying to load routes but the .env may not yet be configured.